### PR TITLE
vim PR 16255, moved to netrw repo

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -4567,6 +4567,14 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
     return
   endif
 
+  if (a:cursor==1) && exists("w:netrw_liststyle") && (w:netrw_liststyle < s:TREELIST)
+    if exists("w:netrw_bannercnt")
+      call cursor(w:netrw_bannercnt, 1)
+    else
+      call cursor(1, 1)
+    endif
+  endif
+
   " NetrwBrowseChgDir; save options and initialize {{{3
   call s:SavePosn(s:netrw_posn)
   NetrwKeepj call s:NetrwOptionsSave("s:")


### PR DESCRIPTION
**Problem:** 

netrw cursor follows current line cursor when **entering** child node in all list views except tree view (in that case the problem does not apply).

**Possible solution:** 

check `w:netrw_liststyle` and and `a:cursor` in `s:NetrwBrowseChgDir` from `autoload/netrw.vim` to properly set the cursor line position.
