### PR TITLE
fix: s:WARNING is not defined in the os module

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -10293,6 +10293,18 @@ fun! netrw#Call(funcname,...)
 endfun
 
 " ---------------------------------------------------------------------
+" netrw#LogLevel: returns the specified loglevel
+fun! netrw#LogLevel(level)
+  if a:level == 'WARNING'
+    return s:WARNING
+  elseif a:level == 'NOTE'
+    return s:NOTE
+  elseif a:level == 'ERROR'
+    return s:ERROR
+  endif
+endfun
+
+" ---------------------------------------------------------------------
 " netrw#Expose: allows UserMaps and pchk to look at otherwise script-local variables {{{2
 "               I expect this function to be used in
 "                 :PChkAssert netrw#Expose("netrwmarkfilelist")

--- a/autoload/netrw/os.vim
+++ b/autoload/netrw/os.vim
@@ -19,7 +19,7 @@ function! netrw#os#Execute(cmd)
     endif
 
     if v:shell_error
-        call netrw#ErrorMsg(s:WARNING, "shell signalled an error", 106)
+        call netrw#ErrorMsg(netrw#LogLevel('ERROR'), "shell signalled an error", 106)
     endif
 endfunction
 


### PR DESCRIPTION
If we don't want the variables to be globals, we must use a helper function to return the correct value from the netrw.vim autoload script.

Also, it seems that when netrw#os#Execute() fails, this should indicate an ERROR and not just a WARNING, so let's just increase the loglevel for the error case.