### PR TITLE
don't overwrite copy, copydir, mkdir and move command options

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -124,10 +124,10 @@ let s:has_balloon = !has('nvim') &&
 
 " ---------------------------------------------------------------------
 " Default option values: {{{2
-let g:netrw_localcopycmdopt    = ""
-let g:netrw_localcopydircmdopt = ""
-let g:netrw_localmkdiropt      = ""
-let g:netrw_localmovecmdopt    = ""
+call s:NetrwInit("g:netrw_localcopycmdopt","")
+call s:NetrwInit("g:netrw_localcopydircmdopt","")
+call s:NetrwInit("g:netrw_localmkdiropt","")
+call s:NetrwInit("g:netrw_localmovecmdopt","")
 
 " ---------------------------------------------------------------------
 " Default values for netrw's global protocol variables {{{2
@@ -334,7 +334,7 @@ if !exists("g:netrw_localcopycmd")
       let g:netrw_localcopycmd= "cp"
     else
       let g:netrw_localcopycmd   = expand("$COMSPEC", v:true)
-      let g:netrw_localcopycmdopt= " /c copy"
+      call s:NetrwInit("g:netrw_localcopycmdopt"," /c copy")
     endif
   elseif has("unix") || has("macunix")
     let g:netrw_localcopycmd= "cp"
@@ -346,17 +346,17 @@ if !exists("g:netrw_localcopydircmd")
   if has("win32")
     if g:netrw_cygwin
       let g:netrw_localcopydircmd   = "cp"
-      let g:netrw_localcopydircmdopt= " -R"
+      call s:NetrwInit("g:netrw_localcopydircmdopt"," -R")
     else
       let g:netrw_localcopydircmd   = expand("$COMSPEC", v:true)
-      let g:netrw_localcopydircmdopt= " /c xcopy /e /c /h /i /k"
+      call s:NetrwInit("g:netrw_localcopydircmdopt"," /c xcopy /e /c /h /i /k")
     endif
   elseif has("unix")
     let g:netrw_localcopydircmd   = "cp"
-    let g:netrw_localcopydircmdopt= " -R"
+    call s:NetrwInit("g:netrw_localcopydircmdopt"," -R")
   elseif has("macunix")
     let g:netrw_localcopydircmd   = "cp"
-    let g:netrw_localcopydircmdopt= " -R"
+    call s:NetrwInit("g:netrw_localcopydircmdopt"," -R")
   else
     let g:netrw_localcopydircmd= ""
   endif
@@ -369,8 +369,8 @@ if has("win32")
   if g:netrw_cygwin
     call s:NetrwInit("g:netrw_localmkdir","mkdir")
   else
-    let g:netrw_localmkdir   = expand("$COMSPEC", v:true)
-    let g:netrw_localmkdiropt= " /c mkdir"
+    call s:NetrwInit("g:netrw_localmkdir",expand("$COMSPEC", v:true))
+    call s:NetrwInit("g:netrw_localmkdiropt"," /c mkdir")
   endif
 else
   call s:NetrwInit("g:netrw_localmkdir","mkdir")
@@ -388,7 +388,7 @@ if !exists("g:netrw_localmovecmd")
       let g:netrw_localmovecmd= "mv"
     else
       let g:netrw_localmovecmd   = expand("$COMSPEC", v:true)
-      let g:netrw_localmovecmdopt= " /c move"
+      call s:NetrwInit("g:netrw_localmovecmdopt"," /c move")
     endif
   elseif has("unix") || has("macunix")
     let g:netrw_localmovecmd= "mv"


### PR DESCRIPTION
Hi

Some options (`g:netrw_localcopycmdopt`, `g:netrw_localcopydircmdopt`, `g:netrw_localmkdiropt`, `g:netrw_localmovecmdopt` (and `g:netrw_localmkdir` in the case `has("win32") && !g:netrw_cygwin`)) weren't being checked if they were unsetted before being defaulted.

I tested this on my machine (unix) for a while and it seems to work as intended, even though these options are only sometimes used by netrw (e.g., `g:netrw_localmkdir` and `netrw_localcopydiropt` are only used if `!has("*mkdir")`) ^^