### PR TITLE
fix: directory netrw-mc error on unix-like systems

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -6283,6 +6283,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
     if isdirectory(s:NetrwFile(args))
       "    call Decho("args<".args."> is a directory",'~'.expand("<slnum>"))
       let copycmd= g:netrw_localcopydircmd
+      let copycmdopt= g:netrw_localcopydircmdopt
       "    call Decho("using copydircmd<".copycmd.">",'~'.expand("<slnum>"))
       if !g:netrw_cygwin && has("win32")
         " window's xcopy doesn't copy a directory to a target properly.  Instead, it copies a directory's
@@ -6293,6 +6294,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
       endif
     else
       let copycmd= g:netrw_localcopycmd
+      let copycmdopt= g:netrw_localcopycmdopt
     endif
     if g:netrw_localcopycmd =~ '\s'
       let copycmd     = substitute(copycmd,'\s.*$','','')
@@ -6303,9 +6305,9 @@ fun! s:NetrwMarkFileCopy(islocal,...)
     endif
     "   call Decho("args   <".args.">",'~'.expand("<slnum>"))
     "   call Decho("tgt    <".tgt.">",'~'.expand("<slnum>"))
-    "   call Decho("copycmd<".copycmd.">",'~'.expand("<slnum>"))
-    "   call Decho("system(".copycmd." '".args."' '".tgt."')",'~'.expand("<slnum>"))
-    call system(copycmd.g:netrw_localcopycmdopt." '".args."' '".tgt."'")
+    "   call Decho("copycmd<".copycmd.copycmdopt.">",'~'.expand("<slnum>"))
+    "   call Decho("system(".copycmd.copycmdopt." '".args."' '".tgt."')",'~'.expand("<slnum>"))
+    call system(copycmd.copycmdopt." '".args."' '".tgt."'")
     if v:shell_error != 0
       if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && g:netrw_keepdir
         call netrw#ErrorMsg(s:ERROR,"copy failed; perhaps due to vim's current directory<".getcwd()."> not matching netrw's (".b:netrw_curdir.") (see :help netrw-cd)",101)


### PR DESCRIPTION
When attempting to copy a marked directory to a target directory the `g:netrw_localcopydircmdopt` was ignored resulting on unix systems to attempt to use the `cp` command without the required `-R` argument.

This change captures the `g:netrw_localcopydircmdopt` value and appends it to the system() call when the marked file(s) is a directory.

Setup:

```bash
mkdir /tmp/netrw-test
mkdir /tmp/netrw-test/foo
mkdir /tmp/netrw-test/bar
mkdir /tmp/netrw-test/bar/baz
touch /tmp/netrw-test/bar/baz/test.txt
```

To recreate the issue:

1. run `VIMRUNTIME=./runtime/ ./src/vim /tmp/netrw-test`
2. place cursor on `foo` and type `mt` to set the target
3. place cursor on `bar` and type `<Enter>`
4. place cursor on `baz` and type `mf` to mark a directory
5. type `mc` to copy the directory

[![asciicast](https://asciinema.org/a/r25R0GE9KJZKPLY5zF8w3rKtn.svg)](https://asciinema.org/a/r25R0GE9KJZKPLY5zF8w3rKtn)