### PR TITLE
fix for browse open with multiple windows

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -6693,8 +6693,7 @@ function! s:NetrwMenu(domenu)
         elseif !a:domenu
             let s:netrwcnt = 0
             let curwin     = winnr()
-            keepjumps windo if getline(2) =~# "Netrw"
-            let s:netrwcnt = s:netrwcnt + 1
+            windo if getline(2) =~# "Netrw" | let s:netrwcnt= s:netrwcnt + 1 | endif
         endif
         exe curwin."wincmd w"
 


### PR DESCRIPTION
to reproduce bug:

1] open a file
2] modify it, but do not save it
3] split the window
4] in one of the two split windows, ":e %:h" to open netrw on the containing folder
5] using netrw browse and highlight a different file in the same folder
6] attempt to open it by hitting return

netrw will ignore g:netrw_browse_split and attempt to open the file in the other window, and fail due to that window containing a modified buffer

fix is to revert the change to this logic introduced by [7e8936934159](https://github.com/djnz00/netrw.vim/commit/7e8936934159caaaa2d1228b31693f1b7ac905fe)  subsequently further modified by [b83083bd23e0](https://github.com/djnz00/netrw.vim/commit/b83083bd23e01e26b3536f66cbb67f244872f8e7) (Note: the latter commit was a bulk re-indent which also edited this logic)