### PR TITLE
Tune local file listing especially for Windows network drives

### DIFF
--- a/autoload/netrw.vim
+++ b/autoload/netrw.vim
@@ -8705,8 +8705,7 @@ function! s:NetrwLocalListingList(dirname,setmaxfilenamelen)
     " get the list of files contained in the current directory
     let dirname    = a:dirname
     let dirnamelen = strlen(dirname)
-    let filelist   = netrw#fs#Glob(dirname,"*",0)
-    let filelist   = filelist + netrw#fs#Glob(dirname,".*",0)
+    let filelist   = map(['.', '..'] + readdir(dirname), 'netrw#fs#PathJoin(dirname, v:val)')
 
     if g:netrw_cygwin == 0 && has("win32")
     elseif index(filelist,'..') == -1 && dirname !~ '/'
@@ -8722,19 +8721,20 @@ function! s:NetrwLocalListingList(dirname,setmaxfilenamelen)
     let resultfilelist = []
     for filename in filelist
 
-        if getftype(filename) == "link"
+        let ftype = getftype(filename)
+        if ftype ==# "link"
             " indicate a symbolic link
             let pfile= filename."@"
 
-        elseif getftype(filename) == "socket"
+        elseif ftype ==# "socket"
             " indicate a socket
             let pfile= filename."="
 
-        elseif getftype(filename) == "fifo"
+        elseif ftype ==# "fifo"
             " indicate a fifo
             let pfile= filename."|"
 
-        elseif isdirectory(s:NetrwFile(filename))
+        elseif ftype ==# "dir"
             " indicate a directory
             let pfile= filename."/"
 


### PR DESCRIPTION
To avoid the slowness for Windows network drives (mounted onto some drive letters),
tweaked local file listing:

* Replace `netrw#fs#Glob()` with `readdir()`
    - There it just want sub entry list of the target directory,
      but `glob()`-ing looks taking much time.
* Just run `getftype()` once
    - For remote entries, each `getftype()` would take long.
